### PR TITLE
15 use aws secrets manager to store password for the rstudio user

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -19,8 +19,8 @@ CERT="/Users/michael/projects/aws/certs/michael.pem"
 
 # create random rstudio password and store it in a secret 
 
-## rstudiopw will be a 12 character base64 string 
-rstudiopw=`openssl rand -base64 12`
+## rstudiopw will be a 12 character random string with mixed upper and lowercase characters + numbers
+rstudiopw=`python -c "import random,string; x=''.join(random.choices(string.ascii_uppercase + string.ascii_lowercase + string.digits, k=12));print(x)"`
 
 ## let's label the secret so it can be recognised again 
 secret_name="rstudiopw-cluster-$CLUSTERNAME"

--- a/deploy.sh
+++ b/deploy.sh
@@ -29,11 +29,11 @@ aws secretsmanager create-secret \
     --description "Secret for rstudio user password on AWS ParallelCluster $CLUSTERNAME" \
     --secret-string "$rstudiopw"
 
-## if secret already exists from a left-over install, let's update it 
 if [ $? -eq 254 ]; then
    secret_id=`aws secretsmanager list-secrets --filters Key=name,Values=$secret_name | jq -r '.SecretList | .[]| .ARN'`
+   echo "secret $secret_name already exists, we need to update it"
    aws secretsmanager update-secret \
-      --secret-id $secret_id \
+      --secret-id "$secret_id" \
       --secret-string "$rstudiopw"
 else
    secret_id=`aws secretsmanager list-secrets --filters Key=name,Values=$secret_name | jq -r '.SecretList | .[]| .ARN'`
@@ -42,6 +42,8 @@ fi
 get_secret=`aws secretsmanager get-secret-value --secret-id $secret_id | jq -r '.SecretString'`
 
 echo "rstudio user password is now set to $get_secret"
+
+
 
 rm -rf tmp
 mkdir -p tmp

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,18 +10,48 @@ KEY="add-keyname"
 # Posit Workbench Version
 PWB_VER=2022.07.2-576.pro12
 PWB_VER=2022.12.0-353.pro20
-PWB_VER=2023.03.0-386.pro1
+PWB_VER=2023.09.1-494.pro2
 #PWB_VER=2023.05.0-daily-312.pro2
 # SLURM Version - use only "-" to resemble git tag version
 SLURM_VER=22-05-5-1
 
 CERT="/Users/michael/projects/aws/certs/michael.pem"
 
+# create random rstudio password and store it in a secret 
+
+## rstudiopw will be a 8 character hex string (2^32 possibilities)
+rstudiopw=`openssl rand -hex 4`
+
+## let's label the secret so it can be recognised again 
+secret_name="rstudiopw-cluster-$CLUSTERNAME"
+aws secretsmanager create-secret \
+    --name $secret_name \
+    --description "Secret for rstudio user password on AWS ParallelCluster $CLUSTERNAME" \
+    --secret-string "$rstudiopw"
+
+## if secret already exists from a left-over install, let's update it 
+if [ $? -eq 254 ]; then
+   secret_id=`aws secretsmanager list-secrets --filters Key=name,Values=$secret_name | jq -r '.SecretList | .[]| .ARN'`
+   aws secretsmanager update-secret \
+      --secret-id $secret_id \
+      --secret-string "$rstudiopw"
+else
+   secret_id=`aws secretsmanager list-secrets --filters Key=name,Values=$secret_name | jq -r '.SecretList | .[]| .ARN'`
+fi
+
+get_secret=`aws secretsmanager get-secret-value --secret-id $secret_id | jq -r '.SecretString'`
+
+echo "rstudio user password is now set to $get_secret"
+
 rm -rf tmp
 mkdir -p tmp
 cp -Rf scripts/* tmp
 cat scripts/aliases.sh | sed "s#CERT#${CERT}#" > tmp/aliases.sh
-cat scripts/install-rsw.sh | sed "s/PWB_VER/$PWB_VER/" | sed "s#S3_BUCKETNAME#${S3_BUCKETNAME}#g" > tmp/install-rsw.sh
+cat scripts/install-rsw.sh | sed "s/PWB_VER/$PWB_VER/" \
+   | sed "s#S3_BUCKETNAME#${S3_BUCKETNAME}#g" \
+   | sed "s#SECRET#$get_secret#g"> tmp/install-rsw.sh
+
+cat scripts/install-compute.sh | sed "s#SECRET#$get_secret#g" > tmp/install-compute.sh
 
 for i in scripts/*.sdef      
 do

--- a/deploy.sh
+++ b/deploy.sh
@@ -19,8 +19,8 @@ CERT="/Users/michael/projects/aws/certs/michael.pem"
 
 # create random rstudio password and store it in a secret 
 
-## rstudiopw will be a 8 character hex string (2^32 possibilities)
-rstudiopw=`openssl rand -hex 4`
+## rstudiopw will be a 12 character base64 string 
+rstudiopw=`openssl rand -base64 12`
 
 ## let's label the secret so it can be recognised again 
 secret_name="rstudiopw-cluster-$CLUSTERNAME"

--- a/scripts/install-compute.sh
+++ b/scripts/install-compute.sh
@@ -15,7 +15,7 @@ apt-get install -y libfreetype6-dev libpng-dev libtiff5-dev
 groupadd --system --gid 8787 rstudio
 useradd -s /bin/bash -m  -d /data/rstudio --system --gid rstudio --uid 8787 rstudio
 
-echo -e "Testme1234\nTestme1234" | passwd rstudio
+echo -e "SECRET\nSECRET" | passwd rstudio
 
 apt-get install -y libzmq3-dev  libglpk40 libnode-dev
 

--- a/scripts/install-compute.sh
+++ b/scripts/install-compute.sh
@@ -15,6 +15,7 @@ apt-get install -y libfreetype6-dev libpng-dev libtiff5-dev
 groupadd --system --gid 8787 rstudio
 useradd -s /bin/bash -m  -d /data/rstudio --system --gid rstudio --uid 8787 rstudio
 
+# below SECRET string will be replaced by actual secret value upon cluster deployment 
 echo -e "SECRET\nSECRET" | passwd rstudio
 
 apt-get install -y libzmq3-dev  libglpk40 libnode-dev

--- a/scripts/install-rsw.sh
+++ b/scripts/install-rsw.sh
@@ -139,7 +139,7 @@ groupadd --system --gid 8788 rstudio-admins
 groupadd --system --gid 8789 rstudio-superuser-admins
 usermod -G rstudio-admins,rstudio-superuser-admins rstudio
  
-echo -e "Testme1234\nTestme1234" | passwd rstudio
+echo -e "SECRET\nSECRET" | passwd rstudio
 
 cat  > /home/rstudio/.Rprofile << EOF
 #set SLURM binaries PATH so that RSW Launcher jobs work

--- a/scripts/install-rsw.sh
+++ b/scripts/install-rsw.sh
@@ -138,7 +138,8 @@ useradd -s /bin/bash -m -d /data/rstudio --system --gid rstudio --uid 8787 rstud
 groupadd --system --gid 8788 rstudio-admins
 groupadd --system --gid 8789 rstudio-superuser-admins
 usermod -G rstudio-admins,rstudio-superuser-admins rstudio
- 
+
+# below SECRET string will be replaced by actual secret value upon cluster deployment 
 echo -e "SECRET\nSECRET" | passwd rstudio
 
 cat  > /home/rstudio/.Rprofile << EOF


### PR DESCRIPTION
This PR is addressing #15.

The new script in `deploy.sh` will ensure to create a new secret if it does not exist or will automatically update an existing secret (existing from a previous AWS ParallelCluster installation). 
Secret is labelled with cluster name which is a unique identifier for each ParallelCluster installation.
Upon cluster deployment, the `deploy.sh` will replace any occurrence of `SECRET` in the scripts `install-rsw.sh` and `install-compute.sh` with the new secret, copy the scripts to a S3 bucket and eventually AWS ParallelCluster will use those scripts to build the cluster. 

Sample output for `script.sh` that is the new part of `deploy.sh` below showing the creating and update capability of the new patch, 

```
michael@host % export CLUSTERNAME=test5
michael@host % bash script.sh
{
    "ARN": "arn:aws:secretsmanager:eu-west-1:637485797898:secret:rstudiopw-cluster-test5-UpRLDp",
    "Name": "rstudiopw-cluster-test5",
    "VersionId": "8d81a2cd-3b8d-4640-8ad2-0cb41bb4bb6c"
}
rstudio user password is now set to 3e935194

% bash script.sh

An error occurred (ResourceExistsException) when calling the CreateSecret operation: The operation failed because the secret rstudiopw-cluster-test5 already exists.
secret rstudiopw-cluster-test5 already exists, we need to update it
{
    "ARN": "arn:aws:secretsmanager:eu-west-1:637485797898:secret:rstudiopw-cluster-test5-UpRLDp",
    "Name": "rstudiopw-cluster-test5",
    "VersionId": "1592ea97-8321-4a70-a344-1bb97c5db6c5"
}
rstudio user password is now set to 2ef2264f
```